### PR TITLE
Commandline args

### DIFF
--- a/VOM_Fortran/Makefile
+++ b/VOM_Fortran/Makefile
@@ -30,7 +30,7 @@ FCFLAGS =
 FLFLAGS =
 
 #source objects
-SRC = VOM-code/modules.f90 VOM-code/coreprog.f90 VOM-code/sample.f90 VOM-code/sce.f90 VOM-code/transpmodel.f90 VOM-code/watbal.f90 
+SRC = VOM-code/modules.f90 VOM-code/readdata.f90 VOM-code/coreprog.f90 VOM-code/sample.f90 VOM-code/sce.f90 VOM-code/transpmodel.f90 VOM-code/watbal.f90 
 
 TESTS = VOM_test/test_tmp/model.x
 

--- a/VOM_Fortran/VOM-code/coreprog.f90
+++ b/VOM_Fortran/VOM-code/coreprog.f90
@@ -42,9 +42,15 @@
       REAL                :: starttime
       REAL                :: currtime
       REAL                :: runtime
+      CHARACTER*100       :: outputpath_tmp ! Temporary outputpath 
+      CHARACTER*100       :: inputpath_tmp  ! Temporary inputpath
+      LOGICAL             :: change_in      ! Change input true/false
+      LOGICAL             :: change_out     ! Change output true/false
 
       beststat = 0
       call cpu_time(starttime)
+
+      call read_commandline(outputpath_tmp, inputpath_tmp, change_in, change_out)
 
 !     * Parameter definitions
 

--- a/VOM_Fortran/VOM-code/modules.f90
+++ b/VOM_Fortran/VOM-code/modules.f90
@@ -63,7 +63,7 @@
       CHARACTER(len=*),parameter :: sfile_dailyweather  = 'dailyweather.prn'
       CHARACTER(len=*),parameter :: sfile_hourlyweather = 'hourlyweather.prn'
 
-      CHARACTER(len=*),parameter :: sfile_namelist      = 'vom_namelist'
+      CHARACTER*100              :: sfile_namelist      = 'vom_namelist'
       CHARACTER(len=*),parameter :: sfile_outputlist    = 'output_namelist'
       CHARACTER(len=*),parameter :: sfile_resultshourly = 'results_hourly.txt'
       CHARACTER(len=*),parameter :: sfile_resultsdaily  = 'results_daily.txt'

--- a/VOM_Fortran/VOM-code/readdata.f90
+++ b/VOM_Fortran/VOM-code/readdata.f90
@@ -1,0 +1,64 @@
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+!
+! Read data needed to run the VOM
+!   Parameter optimisation algorithm based on a paper by Duan et al.
+!   (1993, J. Opt. Theory and Appl., 76, 501--521).
+!
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+!
+! Currently only includes the reading of command line arguments
+! Needs to contain all subroutines that read data in the future
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+!
+! Copyright (C) 2008 Stan Schymanski
+!
+!   This program is free software: you can redistribute it and/or modify
+!   it under the terms of the GNU General Public License as published by
+!   the Free Software Foundation, either version 3 of the License, or
+!   (at your option) any later version.
+!
+!   This program is distributed in the hope that it will be useful,
+!   but WITHOUT ANY WARRANTY; without even the implied warranty of
+!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+!   GNU General Public License for more details.
+!
+!   You should have received a copy of the GNU General Public License
+!   along with this program. If not, see <http://www.gnu.org/licenses/>.
+!
+!%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+
+subroutine read_commandline()
+      use vom_vegwat_mod
+      implicit none
+
+     integer :: num_args, ix
+     character(len=100), dimension(:), allocatable :: args
+
+     num_args = command_argument_count()
+     allocate(args(num_args))  ! I've omitted checking the return status of the allocation 
+
+     do ix = 1, num_args
+         call get_command_argument(ix,args(ix))
+         ! now parse the argument as you wis
+     end do
+
+
+     do ix = 1, num_args
+        if(args(ix) .eq. "-i") then
+           i_inputpath = args(ix+1)
+        end if
+
+        if(args(ix) .eq. "-o") then
+           i_outputpath = args(ix+1)
+        end if
+
+     end do
+
+     write(*,*) i_inputpath
+     write(*,*) i_outputpath
+
+end subroutine read_commandline

--- a/VOM_Fortran/VOM-code/readdata.f90
+++ b/VOM_Fortran/VOM-code/readdata.f90
@@ -50,15 +50,14 @@ subroutine read_commandline()
      do ix = 1, num_args
         if(args(ix) .eq. "-i") then
            i_inputpath = args(ix+1)
+           write(*,*) "Changed inputpath to:", i_inputpath
         end if
 
         if(args(ix) .eq. "-o") then
            i_outputpath = args(ix+1)
+           write(*,*) "Changed outputpath to:",i_outputpath
         end if
 
      end do
-
-     write(*,*) i_inputpath
-     write(*,*) i_outputpath
 
 end subroutine read_commandline

--- a/VOM_Fortran/VOM-code/readdata.f90
+++ b/VOM_Fortran/VOM-code/readdata.f90
@@ -31,33 +31,59 @@
 
 
 
-subroutine read_commandline()
+subroutine read_commandline(outputpath_tmp, inputpath_tmp, change_in, change_out )
       use vom_vegwat_mod
       implicit none
 
-     integer :: num_args, ix
-     character(len=100), dimension(:), allocatable :: args
+     CHARACTER*100, INTENT(out)                    :: outputpath_tmp ! Temporary outputpath 
+     CHARACTER*100, INTENT(out)                    :: inputpath_tmp  ! Temporary inputpath
+     LOGICAL, INTENT(out)                          :: change_in      ! Change input true/false
+     LOGICAL, INTENT(out)                          :: change_out     ! Change output true/false
 
+     CHARACTER(len=100), DIMENSION(:), ALLOCATABLE :: args           ! array for arguments
+     INTEGER                                       :: ix             ! Counter
+     INTEGER                                       :: num_args       ! Number of arguments
+
+
+     !count arguments
      num_args = command_argument_count()
-     allocate(args(num_args))  ! I've omitted checking the return status of the allocation 
+
+     !create array to save arguments
+     allocate(args(num_args))  
 
      do ix = 1, num_args
+         !loop over arguments and save them
          call get_command_argument(ix,args(ix))
-         ! now parse the argument as you wis
      end do
 
+     change_in  = .FALSE.
+     change_out = .FALSE.
 
+     !loop over saved arguments and check flags
      do ix = 1, num_args
+
+        !check inputpath
         if(args(ix) .eq. "-i") then
-           i_inputpath = args(ix+1)
-           write(*,*) "Changed inputpath to:", i_inputpath
+           inputpath_tmp = args(ix+1)
+           change_in = .True.
         end if
 
+        !check outputpath
         if(args(ix) .eq. "-o") then
-           i_outputpath = args(ix+1)
-           write(*,*) "Changed outputpath to:",i_outputpath
+           outputpath_tmp = args(ix+1)
+           change_out = .True.
+        end if
+
+        !check namelist and read again if needed
+        if(args(ix) .eq. "-n") then
+           sfile_namelist = args(ix+1)
+           write(*,*) "Changed vom_namelist:", sfile_namelist
         end if
 
      end do
+
+
+
+
 
 end subroutine read_commandline

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -424,7 +424,11 @@
       use vom_vegwat_mod
       implicit none
 
-      INTEGER :: iostat
+      INTEGER                        :: iostat
+      CHARACTER*100                  :: outputpath_tmp ! Temporary outputpath 
+      CHARACTER*100                  :: inputpath_tmp  ! Temporary inputpath
+      LOGICAL                        :: change_in      ! Change input true/false
+      LOGICAL                        :: change_out     ! Change output true/false
 
 !     * Definition of variable parameters
 
@@ -444,6 +448,9 @@
       namelist /input2par/ i_lat, i_cz, i_cgs, i_zr, i_go, i_ksat,     &
      &                     i_thetar, i_thetas, i_nvg, i_avg, i_delz
 
+
+      call read_commandline(outputpath_tmp, inputpath_tmp, change_in, change_out)
+
 !     * Input of variable parameters from the parameter file
 
       open(kfile_namelist, FILE=sfile_namelist, STATUS='old',          &
@@ -454,8 +461,17 @@
       endif
       close(kfile_namelist)
 
+    !change input and/or outputpaths
+    if(change_in .eqv. .True.) then
+        i_inputpath = inputpath_tmp
+        write(*,*) "Changed inputpath to:", i_inputpath
+     end if
 
-      call read_commandline()
+     if(change_out .eqv. .True.) then
+        i_outputpath = outputpath_tmp
+        write(*,*) "Changed outputpath to:", i_outputpath
+     end if
+
 
 
       c_epsln = i_thetas - i_thetar     ! epsilon, porosity see Reggiani (2000)

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -454,6 +454,10 @@
       endif
       close(kfile_namelist)
 
+
+      call read_commandline()
+
+
       c_epsln = i_thetas - i_thetar     ! epsilon, porosity see Reggiani (2000)
       i_mvg = 1.d0 - (1.d0 / i_nvg)     ! van Genuchten soil parameter m
 

--- a/VOM_Fortran/VOM-docu/html_docu/HowToRun.html
+++ b/VOM_Fortran/VOM-docu/html_docu/HowToRun.html
@@ -190,6 +190,27 @@ and the model should always be run with the directory of this namelist as workin
         </tbody>
     </table>
 
+    <p> All options can be specified in the VOM_namelist. The inputpath, outputpath and VOM_namelist can also be specified on the command line, overruling the values set in the VOM_namelist <p>
+   <table border="1" width="100%">
+      <tbody>
+        <tr>
+          <td>-i</td>
+          <td>Inputpath to directory with dailyweather.prn, and optionally pars.txt. </td>
+        </tr>
+        <tr>
+          <td>-o</td>
+          <td>Outputpath for all outputfiles.</td>
+        </tr>
+        <tr>
+          <td>-n</td>
+          <td>The VOM_namelist (filename can be different)</td>
+        </tr>
+        </tbody>
+    </table>
+
+
+
+
     <h3>Running the model in parallel</h3>
     The SCE-algorithm (mode 1) can be run in parallel. The number of threads has to be specified in the VOM_namelist, with the variable <pre>n_threads</pre> 
     When specified, the SCE-algorithm runs over the different complexes in parallel (one complex per thread). 


### PR DESCRIPTION
I added this in order to make it work better with renku. Untill now I used a workaround by using a script and passing the input/output directories as dummies. Now the executable can take the arguments -i, -o, -n for inputpath, outputpath and namelist. It overwrites the values set in the namelist. 