### PR TITLE
changed increment cover back to linear

### DIFF
--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1052,8 +1052,7 @@
 
       else       
          pcg_d(2)     = MIN(1.d0 - o_cai, c_pcgmin)
-         pcg_d(:)     = pcg_d(2) * (/1.0d0-i_incrcovg,1.0d0,1.0d0+i_incrcovg/)  ! perc. change grass cover
-         !pcg_d(:)     = pcg_d(2) + (/-i_incrcovg,0.0d0,i_incrcovg/)  ! vector with values varying by 1%
+         pcg_d(:)     = pcg_d(2) + (/-i_incrcovg,0.0d0,i_incrcovg/)  ! vector with values varying by 1%
          pcg_d(3)     = MIN(MAX(c_pcgmin, pcg_d(3)), 1.d0 - o_cai)
       end if
 
@@ -1142,8 +1141,7 @@
          end if
 
       else
-         !pcg_d(:)     = pcg_d(2) + (/-i_incrcovg,0.0d0,i_incrcovg/)  ! perc. change grass cover
-         pcg_d(:)     = pcg_d(2) * (/1.0d0-i_incrcovg,1.0d0,1.0d0+i_incrcovg/)  ! perc. change grass cover
+         pcg_d(:)     = pcg_d(2) + (/-i_incrcovg,0.0d0,i_incrcovg/)  ! perc. change grass cover
          pcg_d(:)     = MAX(pcg_d(:), 0.d0)
          pcg_d(3)     = MIN(MAX(c_pcgmin, pcg_d(3)), 1.d0 - o_cai)
       end if


### PR DESCRIPTION
In the LAI-branch I changed how the cover of grasses changed from adding 0.02, to multiplying with 1.02. All other LAI-options are catched by some case select statements. So we can keep all of that in your master as it is optional and you can still run the VOM in the old way. Only these increments for the grasses were changed for running the VOM with and without LAI , so for the time being I changed it back in order to produce to same results as before. 