### PR TITLE
added compiler flag for non-standard installation of netcdf-lib

### DIFF
--- a/VOM_Fortran/Makefile
+++ b/VOM_Fortran/Makefile
@@ -18,7 +18,7 @@ FC      := /usr/bin/gfortran #compiler name and directory
 SRC_PATH = ./src		#path of source files
 OBJ_PATH = ./tmp		#path .o and .mod files
 
-NFDIR := lib/
+
 
 SRC_PATH    := $(abspath $(SRC_PATH:~%=${HOME}%))
 OBJ_PATH   := $(abspath $(OBJ_PATH:~%=${HOME}%))
@@ -30,6 +30,7 @@ FCFLAGS =
 FLFLAGS =
 
 NC_INCLUDE=/usr/include
+NC_LIB := /usr/lib/
 
 #source objects
 SRC = VOM-code/modules.f90 VOM-code/readdata.f90 VOM-code/writedata.f90 VOM-code/coreprog.f90 VOM-code/sample.f90 VOM-code/sce.f90 VOM-code/transpmodel.f90 VOM-code/watbal.f90 
@@ -43,7 +44,7 @@ MSRC = *.mod
 all: $(PROGRAM) 
 		
 $(PROGRAM): $(SRC) 
-	$(FC) -fopenmp -o $@ $^ -static-libgfortran -I${NC_INCLUDE} -lnetcdff; rm $(MSRC)    #;mv $(MSRC) $(OBJ_PATH)
+	$(FC) -fopenmp -o $@ $^ -static-libgfortran -I${NC_INCLUDE} -L${NC_LIB} -lnetcdff; rm $(MSRC)    #;mv $(MSRC) $(OBJ_PATH)
 #	$(FC) -o $@ $^ -I${NFDIR}/include -L${NFDIR}/lib  -static ;mv $(MSRC) $(OBJ_PATH)
 %.o: %.f
 	$(FC) -o $@ $<


### PR DESCRIPTION
I had to add a compiler option for netcdf on the hpc, as it was not in a standard location, and added that now to the makefile. In this way there is a standard directory it searches for netcdf, but it can be overruled by defining the directories after make. 