### PR TITLE
Lai july2022

### DIFF
--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1563,7 +1563,13 @@
       INTEGER:: jj      
       INTEGER:: ilay
       REAL*8 :: lag_sun(3)          
-      REAL*8 :: lat_sun(3)                
+      REAL*8 :: lat_sun(3)   
+      REAL*8 :: fpar_sunt          
+      REAL*8 :: fpar_sung                
+      REAL*8 :: fpar_shadet          
+      REAL*8 :: fpar_shadeg 
+      
+                   
       REAL*8 :: kappa
       
       select case(i_lai_function)
@@ -1659,17 +1665,25 @@
         &             / jmaxt_h(:))) * jmaxt_h(:)  ! (3.23), (Out[311])    
         
               case(3) ! shaded and sunlit, with diffuse and direct radiation
+              
+                   fpar_sunt = 1.0d0 - p_E ** (-lat_sun(ii) * kappa * sqrt(i_alpha_abs) )                     
+                   fpar_shadet = 1.0d0 - p_E ** (- ( lai_lt(ii) - lat_sun(ii)) * kappa * sqrt(i_alpha_abs) ) 
+              
                    jactt(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
-        &             / jmaxt_h(:))) * jmaxt_h(:) * frac_sunt(ii) ) +                                      &
+        &             / jmaxt_h(:))) * jmaxt_h(:) * fpar_sunt) +                                      &
         &                          ( (1.d0 - p_E ** (-(i_alpha  * pardiff_h(th_) )                    &    
-        &             / jmaxt_h(:))) * jmaxt_h(:) * frac_shadet(ii) )
+        &             / jmaxt_h(:))) * jmaxt_h(:) * fpar_shadet )
         
-              case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit        
+              case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit      
+              
+                   fpar_sunt = 1.0d0 - p_E ** (-lat_sun(ii) * kappa * sqrt(i_alpha_abs) )                     
+                   fpar_shadet = 1.0d0 - p_E ** (- ( lai_lt(ii) - lat_sun(ii)) * kappa * sqrt(i_alpha_abs) )                                   
+                
                    jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
-        &             / jmaxt_h(:))) * jmaxt_h(:) * frac_sunt(ii)
+        &             / jmaxt_h(:))) * jmaxt_h(:) * fpar_sunt
 
                    jactts(:,ii)   =  (1.d0 - p_E ** (-(i_alpha  * pardiff_h(th_) )                    &    
-        &             / jmaxts_h(:))) * jmaxts_h(:) * frac_shadet(ii) 
+        &             / jmaxts_h(:))) * jmaxts_h(:) * fpar_shadet
         
              end select
         end do
@@ -1688,18 +1702,27 @@
                jactg(:,ii) = (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * par_h(th_))           &
              &       / jmaxg_h(:))) * jmaxg_h(:)  ! (3.23), (Out[311])
                           
-              case(3) ! shaded and sunlit, with diffuse and direct radiation
+              case(3) ! shaded and sunlit, with diffuse and direct radiation.
+              
+                   fpar_sung = 1.0d0 - p_E ** (-lag_sun(ii) * kappa * sqrt(i_alpha_abs) )                     
+                   fpar_shadeg = 1.0d0 - p_E ** (- ( lai_lg(ii) - lag_sun(ii)) * kappa * sqrt(i_alpha_abs) )               
+              
                jactg(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
-             &     / jmaxg_h(:))) * jmaxg_h(:)  * frac_sung(ii) ) +                                &
+             &     / jmaxg_h(:))) * jmaxg_h(:)  * fpar_sung ) +                                &
              &     ( (1.d0 - p_E ** (-(i_alpha * pardiff_h(th_) )                                  &    
-             &     / jmaxg_h(:))) * jmaxg_h(:) * frac_shadeg(ii) )
+             &     / jmaxg_h(:))) * jmaxg_h(:) * fpar_shadeg )
                       
               case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit
+              
+                   fpar_sung = 1.0d0 - p_E ** (-lag_sun(ii) * kappa * sqrt(i_alpha_abs) )                     
+                   fpar_shadeg = 1.0d0 - p_E ** (- ( lai_lg(ii) - lag_sun(ii)) * kappa * sqrt(i_alpha_abs) )                 
+              
+              
                jactg(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
-             &     / jmaxg_h(:))) * jmaxg_h(:) * frac_sung(ii) 
+             &     / jmaxg_h(:))) * jmaxg_h(:) * fpar_sung 
              
                jactgs(:,ii)   = (1.d0 - p_E ** (-(i_alpha * pardiff_h(th_) )                                  &    
-             &     / jmaxgs_h(:))) * jmaxgs_h(:) * frac_shadeg(ii)   
+             &     / jmaxgs_h(:))) * jmaxgs_h(:) * fpar_shadeg  
               
              
           end select

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1651,25 +1651,25 @@
         
             select case(i_lai_function)
               case(1) ! no dynamic LAI, fpar is set to 1
-                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * par_h(th_))           &    
+                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha  * par_h(th_))           &    
         &             / jmaxt_h(:))) * jmaxt_h(:)  ! (3.23), (Out[311])
        
               case(2) ! dynamic LAI, with fpar-calculation
-                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * par_h(th_))           &    
+                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * par_h(th_))           &    
         &             / jmaxt_h(:))) * jmaxt_h(:)  ! (3.23), (Out[311])    
         
               case(3) ! shaded and sunlit, with diffuse and direct radiation
-                   jactt(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * (pardir_h(th_) + pardiff_h(th_)) ) &    
+                   jactt(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
         &             / jmaxt_h(:))) * jmaxt_h(:) * frac_sunt(ii) ) +                                      &
-        &                          ( (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * pardiff_h(th_) )                    &    
+        &                          ( (1.d0 - p_E ** (-(i_alpha  * pardiff_h(th_) )                    &    
         &             / jmaxt_h(:))) * jmaxt_h(:) * frac_shadet(ii) )
         
               case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit        
-                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * (pardir_h(th_) + pardiff_h(th_)) ) &    
-        &             / jmaxt_h(:))) * jmaxt_h(:) 
+                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
+        &             / jmaxt_h(:))) * jmaxt_h(:) * frac_sunt(ii)
 
-                   jactts(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * pardiff_h(th_) )                    &    
-        &             / jmaxts_h(:))) * jmaxts_h(:)   
+                   jactts(:,ii)   =  (1.d0 - p_E ** (-(i_alpha  * pardiff_h(th_) )                    &    
+        &             / jmaxts_h(:))) * jmaxts_h(:) * frac_shadet(ii) 
         
              end select
         end do
@@ -1689,17 +1689,17 @@
              &       / jmaxg_h(:))) * jmaxg_h(:)  ! (3.23), (Out[311])
                           
               case(3) ! shaded and sunlit, with diffuse and direct radiation
-               jactg(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * (pardir_h(th_) + pardiff_h(th_)) ) &    
+               jactg(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
              &     / jmaxg_h(:))) * jmaxg_h(:)  * frac_sung(ii) ) +                                &
-             &     ( (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * pardiff_h(th_) )                                  &    
+             &     ( (1.d0 - p_E ** (-(i_alpha * pardiff_h(th_) )                                  &    
              &     / jmaxg_h(:))) * jmaxg_h(:) * frac_shadeg(ii) )
                       
               case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit
-               jactg(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * (pardir_h(th_) + pardiff_h(th_)) ) &    
-             &     / jmaxg_h(:))) * jmaxg_h(:)   
+               jactg(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
+             &     / jmaxg_h(:))) * jmaxg_h(:) * frac_sung(ii) 
              
-               jactgs(:,ii)   = (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * pardiff_h(th_) )                                  &    
-             &     / jmaxgs_h(:))) * jmaxgs_h(:)    
+               jactgs(:,ii)   = (1.d0 - p_E ** (-(i_alpha * pardiff_h(th_) )                                  &    
+             &     / jmaxgs_h(:))) * jmaxgs_h(:) * frac_shadeg(ii)   
               
              
           end select
@@ -1739,11 +1739,8 @@
           gstomt = 0.d0
         endif
         transpt = p_a * vd_h(th_) * gstomt  ! (3.28) transpiration rate in mol/s
-        if(i_lai_function == 4) then        
-           etmt__ = frac_sunt(2) * (transpt * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s        
-        else        
-           etmt__ = (transpt * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s
-        end if
+        etmt__ = (transpt * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s
+
 
 !       * calculate stomatal conductance grasses
 
@@ -1774,7 +1771,7 @@
         transpg(:, :, :) = p_a * vd_h(th_) * gstomg(:, :, :)  ! (3.28) transpiration rate in mol/s
         if(i_lai_function == 4) then        
            do ii = 1,3
-              etmg__(:, :, ii) = frac_sung(ii) * (transpg(:, :, ii) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s 
+              etmg__(:, :, ii) = (transpg(:, :, ii) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s 
            end do  
         else
            etmg__(:,:,:) = (transpg(:, :, :) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s        
@@ -1813,7 +1810,7 @@
            endif
            transpts = p_a * vd_h(th_) * gstomts  ! (3.28) transpiration rate in mol/s
 
-           etmts__ = frac_shadet(2) * (transpts * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s        
+           etmts__ = (transpts * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s        
         else     
            gstomts = 0.d0
            transpts = 0.d0      
@@ -1851,7 +1848,7 @@
            transpgs(:,:,:) = p_a * vd_h(th_) * gstomgs(:,:,:)  ! (3.28) transpiration rate in mol/s       
 
            do ii = 1,3           
-              etmgs__(:,:,ii) = frac_shadeg(ii) * (transpgs(:,:,ii) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s    
+              etmgs__(:,:,ii) = (transpgs(:,:,ii) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s    
            end do    
         else  
            gstomgs(:,:,:) = 0.d0
@@ -2246,7 +2243,7 @@
     do ii = 1,3 !loop for LAI values
         
      if(i_lai_function == 4) then
-      asst__(:,ii) = frac_sunt(ii) * ( (4.d0 * ca_h(th_) * gstomt + 8.d0 * gammastar        &
+      asst__(:,ii) =  ( (4.d0 * ca_h(th_) * gstomt + 8.d0 * gammastar        &
         &          * gstomt + jactt(:,ii) - 4.d0 * rlt_h(:) - SQRT((-4.d0    &
         &          * ca_h(th_) * gstomt + 8.d0 * gammastar * gstomt       &
         &          + jactt(:,ii) - 4.d0 * rlt_h(:)) ** 2.d0 + 16.d0          &
@@ -2254,7 +2251,7 @@
         &          + jactt(:,ii) + 8.d0 * rlt_h(:)))) / 8.d0 )  ! (3.22) ; (Out[319])
      
      
-      assts__(:,ii) = frac_shadet(ii) * ( (4.d0 * ca_h(th_) * gstomts + 8.d0 * gammastar        &
+      assts__(:,ii) = ( (4.d0 * ca_h(th_) * gstomts + 8.d0 * gammastar        &
         &          * gstomts + jactts(:,ii) - 4.d0 * rlts_h(:) - SQRT((-4.d0    &
         &          * ca_h(th_) * gstomts + 8.d0 * gammastar * gstomts       &
         &          + jactts(:,ii) - 4.d0 * rlts_h(:)) ** 2.d0 + 16.d0          &
@@ -2279,7 +2276,7 @@
     do ii = 1,3 !loop for LAI values
       do jj = 1,3 !loop for CAI_g values    
         if(i_lai_function == 4) then    
-          assg__(jj,:,ii) =  frac_sung(ii) * ( (4.d0 * ca_h(th_) * gstomg(jj,:,ii) + 8.d0 * gammastar &
+          assg__(jj,:,ii) =   ( (4.d0 * ca_h(th_) * gstomg(jj,:,ii) + 8.d0 * gammastar &
           &         * gstomg(jj,:,ii) + jactg(:,ii) - 4.d0 * rlg_h(:)       &
           &         - SQRT((-4.d0 * ca_h(th_) * gstomg(jj,:,ii) + 8.d0       &
           &         * gammastar * gstomg(jj,:,ii) + jactg(:,ii) - 4.d0        &
@@ -2287,7 +2284,7 @@
           &         * gstomg(jj,:,ii) * (8.d0 * ca_h(th_) * gstomg(jj,:,ii)      &
           &         + jactg(:,ii) + 8.d0 * rlg_h(:)))) / 8.d0)  ! (3.22); (Out[319])
 
-          assgs__(jj,:,ii) =   frac_shadeg(ii) * ( (4.d0 * ca_h(th_) * gstomgs(jj,:,ii) + 8.d0 * gammastar &
+          assgs__(jj,:,ii) =    ( (4.d0 * ca_h(th_) * gstomgs(jj,:,ii) + 8.d0 * gammastar &
           &         * gstomgs(jj,:,ii) + jactgs(:,ii) - 4.d0 * rlgs_h(:)       &
           &         - SQRT((-4.d0 * ca_h(th_) * gstomgs(jj,:,ii) + 8.d0       &
           &         * gammastar * gstomgs(jj,:,ii) + jactgs(:,ii) - 4.d0        &

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1576,6 +1576,7 @@
       REAL*8 :: PARshade     
       REAL*8 :: par_shade_avg           
       REAL*8 :: par_sct                 
+      REAL*8 :: kappa_d                             
             
       
       select case(i_lai_function)
@@ -1612,6 +1613,8 @@
 
       
       case(3, 4) !dynamic LAI, with shaded/sunlit fractions
+      
+      kappa_d = 0.719d0
       
 !       * extinction coefficient (Xiao et al. (2015) eq.6, Campbell and Norman (1998) eq. 15.4)
         kappa_t = sqrt(i_chi_t**2+tan(phi_zenith(th_))**2)/(i_chi_t+1.774*(i_chi_t+1.182)**(-0.733) )        
@@ -1679,8 +1682,8 @@
                     !at the top of the canopy, shaded leaves receive PARdiff                   
                     !at the bottom of canopy, shaded leaves receive                     
                     !take the exponential weighted average of top and bottom (p260, Campbell&Norman):
-                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )   ) ) / &
-                                    ( sqrt(i_alpha_abs) * kappa_t * lai_lt(ii)    ) 
+                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lt(ii) )   ) ) / &
+                                    ( sqrt(i_alpha_abs) * kappa_d* lai_lt(ii)    ) 
               
                     !need to add the scattered direct PAR to the shaded PAR:
                     par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )  -  &
@@ -1707,8 +1710,8 @@
                     !at the top of the canopy, shaded leaves receive PARdiff                   
                     !at the bottom of canopy, shaded leaves receive                                        
                     !take the exponential weighted average of top and bottom (p260, Campbell&Norman):
-                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )   ) ) / &
-                                    ( sqrt(i_alpha_abs) * kappa_t * lai_lt(ii)    ) 
+                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lt(ii) )   ) ) / &
+                                    ( sqrt(i_alpha_abs) * kappa_d * lai_lt(ii)    ) 
               
                     !need to add the scattered direct PAR to the shaded PAR:
                     par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )  -  &
@@ -1755,8 +1758,8 @@
                     !at the top of the canopy, shaded leaves receive PARdiff                   
                     !at the bottom of canopy, shaded leaves receive                    
                     !take the exponential weighted average of top and bottom (p260, Campbell&Norman):
-                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_g * lai_lg(ii) )   ) ) / &
-                                    ( sqrt(i_alpha_abs) * kappa_g * lai_lg(ii)    ) 
+                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lg(ii) )   ) ) / &
+                                    ( sqrt(i_alpha_abs) * kappa_d * lai_lg(ii)    ) 
               
                     !need to add the scattered direct PAR to the shaded PAR:
                     par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_g * lai_lg(ii) )  -  &
@@ -1783,8 +1786,8 @@
                     !at the bottom of canopy, shaded leaves receive                    
                     !take the exponential weighted average of top and bottom (p260, Campbell&Norman):
                      
-                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_g * lai_lg(ii) )   ) ) / &
-                                    ( sqrt(i_alpha_abs) * kappa_g * lai_lg(ii)    ) 
+                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lg(ii) )   ) ) / &
+                                    ( sqrt(i_alpha_abs) * kappa_d * lai_lg(ii)    ) 
               
                     !need to add the scattered direct PAR to the shaded PAR:
                     par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_g * lai_lg(ii) )  -  &

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1694,7 +1694,7 @@
               
                     !----------------------------------------------------------
                     !sunlit leaves
-                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) ) + PARshade  
+                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade  )
               
                    jactt(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * PARsun ) &    
         &             / jmaxt_h(:))) * jmaxt_h(:) *  lat_sun(ii) ) +                                      &
@@ -1722,7 +1722,7 @@
               
                     !----------------------------------------------------------
                     !sunlit leaves
-                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) ) + PARshade                                     
+                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade )
                             
                 
                    jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * PARsun ) &    

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1770,8 +1770,8 @@
               
                     !----------------------------------------------------------
                     !sunlit leaves
-                    PARsun = i_alpha_abs * (kappa_g * pardir_h(th_) ) + PARshade                
-              
+                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade )              
+                    
                     jactg(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * PARsun ) &    
                     &     / jmaxg_h(:))) * jmaxg_h(:)  *  lag_sun(ii)   ) +                                &
                     &     ( (1.d0 - p_E ** (-(i_alpha * PARshade )                                  &    
@@ -1800,8 +1800,7 @@
               
                     !----------------------------------------------------------
                     !sunlit leaves
-                    PARsun = i_alpha_abs * (kappa_g * pardir_h(th_) ) + PARshade                  
-           
+                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade )           
               
                     jactg(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * PARsun ) &    
                     &     / jmaxg_h(:))) * jmaxg_h(:) *  lag_sun(ii)  


### PR DESCRIPTION
This branch had my latest edits for the LAI in the VOM (just before EGU). I think it would be best to merge this into a branch on git@github.com:schymans/VOM.git, then you could start from there. I tried below to give an overview on what I did.

This branch includes a first attempt to separate PAR into PAR shade and PAR sunlit, based on the approach in Campbell & Norman.  I followed the example on p260 (example 15.2). Specifically:

- estimate average PAR on shaded leaves (transpmode.f90, lines 1685 and 1713, first equation p261 Campbell & Norman):

```
                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lt(ii) )   ) ) / &
                                    ( sqrt(i_alpha_abs) * kappa_d* lai_lt(ii)    ) 
```

- determine scattered PAR (transpmode.f90, lines 1689 and 1717)::

```
                    par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )  -  &
                                    pardir_h(th_) * p_E ** (-kappa_t * lai_lt(ii) ) )
```

the above is the same as  the calculation on p261 of Campbell & Norman, with scattered PAR as Qsc = 0.5 (Qbt - Qb), with Qbt the top beam radiation and Qb bottom beam radiation. 

- Eventually, PARshade and PARsun are determined like this:

`                    PARshade = (par_sct + par_shade_avg) * i_alpha_abs`

`                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade )`


 On p261 of Campbell & Norman, these are the equations for Qsh and Qsl.


