### PR TITLE
WIP: LAI

### DIFF
--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1563,7 +1563,13 @@
       INTEGER:: jj      
       INTEGER:: ilay
       REAL*8 :: lag_sun(3)          
-      REAL*8 :: lat_sun(3)                
+      REAL*8 :: lat_sun(3)   
+      REAL*8 :: fpar_sunt          
+      REAL*8 :: fpar_sung                
+      REAL*8 :: fpar_shadet          
+      REAL*8 :: fpar_shadeg 
+      
+                   
       REAL*8 :: kappa
       
       select case(i_lai_function)
@@ -1659,17 +1665,25 @@
         &             / jmaxt_h(:))) * jmaxt_h(:)  ! (3.23), (Out[311])    
         
               case(3) ! shaded and sunlit, with diffuse and direct radiation
+              
+                   fpar_sunt = 1.0d0 - p_E ** (-lat_sun(ii) * kappa * sqrt(i_alpha_abs) )                     
+                   fpar_shadet = 1.0d0 - p_E ** (- ( lai_lt(ii) - lat_sun(ii)) * kappa * sqrt(i_alpha_abs) ) 
+              
                    jactt(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
-        &             / jmaxt_h(:))) * jmaxt_h(:) * frac_sunt(ii) ) +                                      &
+        &             / jmaxt_h(:))) * jmaxt_h(:) * fpar_sunt) +                                      &
         &                          ( (1.d0 - p_E ** (-(i_alpha  * pardiff_h(th_) )                    &    
-        &             / jmaxt_h(:))) * jmaxt_h(:) * frac_shadet(ii) )
+        &             / jmaxt_h(:))) * jmaxt_h(:) * fpar_shadet )
         
-              case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit        
+              case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit      
+              
+                   fpar_sunt = 1.0d0 - p_E ** (-lat_sun(ii) * kappa * sqrt(i_alpha_abs) )                     
+                   fpar_shadet = 1.0d0 - p_E ** (- ( lai_lt(ii) - lat_sun(ii)) * kappa * sqrt(i_alpha_abs) )                                   
+                
                    jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
-        &             / jmaxt_h(:))) * jmaxt_h(:) * frac_sunt(ii)
+        &             / jmaxt_h(:))) * jmaxt_h(:) * fpar_sunt
 
                    jactts(:,ii)   =  (1.d0 - p_E ** (-(i_alpha  * pardiff_h(th_) )                    &    
-        &             / jmaxts_h(:))) * jmaxts_h(:) * frac_shadet(ii) 
+        &             / jmaxts_h(:))) * jmaxts_h(:) * fpar_shadet
         
              end select
         end do
@@ -1688,18 +1702,27 @@
                jactg(:,ii) = (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * par_h(th_))           &
              &       / jmaxg_h(:))) * jmaxg_h(:)  ! (3.23), (Out[311])
                           
-              case(3) ! shaded and sunlit, with diffuse and direct radiation
+              case(3) ! shaded and sunlit, with diffuse and direct radiation.
+              
+                   fpar_sung = 1.0d0 - p_E ** (-lag_sun(ii) * kappa * sqrt(i_alpha_abs) )                     
+                   fpar_shadeg = 1.0d0 - p_E ** (- ( lai_lg(ii) - lag_sun(ii)) * kappa * sqrt(i_alpha_abs) )               
+              
                jactg(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
-             &     / jmaxg_h(:))) * jmaxg_h(:)  * frac_sung(ii) ) +                                &
+             &     / jmaxg_h(:))) * jmaxg_h(:)  * fpar_sung ) +                                &
              &     ( (1.d0 - p_E ** (-(i_alpha * pardiff_h(th_) )                                  &    
-             &     / jmaxg_h(:))) * jmaxg_h(:) * frac_shadeg(ii) )
+             &     / jmaxg_h(:))) * jmaxg_h(:) * fpar_shadeg )
                       
               case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit
+              
+                   fpar_sung = 1.0d0 - p_E ** (-lag_sun(ii) * kappa * sqrt(i_alpha_abs) )                     
+                   fpar_shadeg = 1.0d0 - p_E ** (- ( lai_lg(ii) - lag_sun(ii)) * kappa * sqrt(i_alpha_abs) )                 
+              
+              
                jactg(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
-             &     / jmaxg_h(:))) * jmaxg_h(:) * frac_sung(ii) 
+             &     / jmaxg_h(:))) * jmaxg_h(:) * fpar_sung 
              
                jactgs(:,ii)   = (1.d0 - p_E ** (-(i_alpha * pardiff_h(th_) )                                  &    
-             &     / jmaxgs_h(:))) * jmaxgs_h(:) * frac_shadeg(ii)   
+             &     / jmaxgs_h(:))) * jmaxgs_h(:) * fpar_shadeg  
               
              
           end select

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1651,25 +1651,25 @@
         
             select case(i_lai_function)
               case(1) ! no dynamic LAI, fpar is set to 1
-                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * par_h(th_))           &    
+                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha  * par_h(th_))           &    
         &             / jmaxt_h(:))) * jmaxt_h(:)  ! (3.23), (Out[311])
        
               case(2) ! dynamic LAI, with fpar-calculation
-                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * par_h(th_))           &    
+                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * par_h(th_))           &    
         &             / jmaxt_h(:))) * jmaxt_h(:)  ! (3.23), (Out[311])    
         
               case(3) ! shaded and sunlit, with diffuse and direct radiation
-                   jactt(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * (pardir_h(th_) + pardiff_h(th_)) ) &    
+                   jactt(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
         &             / jmaxt_h(:))) * jmaxt_h(:) * frac_sunt(ii) ) +                                      &
-        &                          ( (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * pardiff_h(th_) )                    &    
+        &                          ( (1.d0 - p_E ** (-(i_alpha  * pardiff_h(th_) )                    &    
         &             / jmaxt_h(:))) * jmaxt_h(:) * frac_shadet(ii) )
         
               case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit        
-                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * (pardir_h(th_) + pardiff_h(th_)) ) &    
-        &             / jmaxt_h(:))) * jmaxt_h(:) 
+                   jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
+        &             / jmaxt_h(:))) * jmaxt_h(:) * frac_sunt(ii)
 
-                   jactts(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * fpar_lt(ii) * pardiff_h(th_) )                    &    
-        &             / jmaxts_h(:))) * jmaxts_h(:)   
+                   jactts(:,ii)   =  (1.d0 - p_E ** (-(i_alpha  * pardiff_h(th_) )                    &    
+        &             / jmaxts_h(:))) * jmaxts_h(:) * frac_shadet(ii) 
         
              end select
         end do
@@ -1689,17 +1689,17 @@
              &       / jmaxg_h(:))) * jmaxg_h(:)  ! (3.23), (Out[311])
                           
               case(3) ! shaded and sunlit, with diffuse and direct radiation
-               jactg(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * (pardir_h(th_) + pardiff_h(th_)) ) &    
+               jactg(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
              &     / jmaxg_h(:))) * jmaxg_h(:)  * frac_sung(ii) ) +                                &
-             &     ( (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * pardiff_h(th_) )                                  &    
+             &     ( (1.d0 - p_E ** (-(i_alpha * pardiff_h(th_) )                                  &    
              &     / jmaxg_h(:))) * jmaxg_h(:) * frac_shadeg(ii) )
                       
               case(4) ! shaded and sunlit, diffuse and direct radiation, different jact-values shaded-sunlit
-               jactg(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * (pardir_h(th_) + pardiff_h(th_)) ) &    
-             &     / jmaxg_h(:))) * jmaxg_h(:)   
+               jactg(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * (pardir_h(th_) + pardiff_h(th_)) ) &    
+             &     / jmaxg_h(:))) * jmaxg_h(:) * frac_sung(ii) 
              
-               jactgs(:,ii)   = (1.d0 - p_E ** (-(i_alpha * fpar_lg(ii) * pardiff_h(th_) )                                  &    
-             &     / jmaxgs_h(:))) * jmaxgs_h(:)    
+               jactgs(:,ii)   = (1.d0 - p_E ** (-(i_alpha * pardiff_h(th_) )                                  &    
+             &     / jmaxgs_h(:))) * jmaxgs_h(:) * frac_shadeg(ii)   
               
              
           end select
@@ -1739,11 +1739,8 @@
           gstomt = 0.d0
         endif
         transpt = p_a * vd_h(th_) * gstomt  ! (3.28) transpiration rate in mol/s
-        if(i_lai_function == 4) then        
-           etmt__ = frac_sunt(2) * (transpt * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s        
-        else        
-           etmt__ = (transpt * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s
-        end if
+        etmt__ = (transpt * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s
+
 
 !       * calculate stomatal conductance grasses
 
@@ -1774,7 +1771,7 @@
         transpg(:, :, :) = p_a * vd_h(th_) * gstomg(:, :, :)  ! (3.28) transpiration rate in mol/s
         if(i_lai_function == 4) then        
            do ii = 1,3
-              etmg__(:, :, ii) = frac_sung(ii) * (transpg(:, :, ii) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s 
+              etmg__(:, :, ii) = (transpg(:, :, ii) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s 
            end do  
         else
            etmg__(:,:,:) = (transpg(:, :, :) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s        
@@ -1813,7 +1810,7 @@
            endif
            transpts = p_a * vd_h(th_) * gstomts  ! (3.28) transpiration rate in mol/s
 
-           etmts__ = frac_shadet(2) * (transpts * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s        
+           etmts__ = (transpts * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s        
         else     
            gstomts = 0.d0
            transpts = 0.d0      
@@ -1851,7 +1848,7 @@
            transpgs(:,:,:) = p_a * vd_h(th_) * gstomgs(:,:,:)  ! (3.28) transpiration rate in mol/s       
 
            do ii = 1,3           
-              etmgs__(:,:,ii) = frac_shadeg(ii) * (transpgs(:,:,ii) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s    
+              etmgs__(:,:,ii) = (transpgs(:,:,ii) * 18.d0) / (10.d0 ** 6.d0)  ! transpiration rate in m/s    
            end do    
         else  
            gstomgs(:,:,:) = 0.d0
@@ -2246,7 +2243,7 @@
     do ii = 1,3 !loop for LAI values
         
      if(i_lai_function == 4) then
-      asst__(:,ii) = frac_sunt(ii) * ( (4.d0 * ca_h(th_) * gstomt + 8.d0 * gammastar        &
+      asst__(:,ii) =  ( (4.d0 * ca_h(th_) * gstomt + 8.d0 * gammastar        &
         &          * gstomt + jactt(:,ii) - 4.d0 * rlt_h(:) - SQRT((-4.d0    &
         &          * ca_h(th_) * gstomt + 8.d0 * gammastar * gstomt       &
         &          + jactt(:,ii) - 4.d0 * rlt_h(:)) ** 2.d0 + 16.d0          &
@@ -2254,7 +2251,7 @@
         &          + jactt(:,ii) + 8.d0 * rlt_h(:)))) / 8.d0 )  ! (3.22) ; (Out[319])
      
      
-      assts__(:,ii) = frac_shadet(ii) * ( (4.d0 * ca_h(th_) * gstomts + 8.d0 * gammastar        &
+      assts__(:,ii) = ( (4.d0 * ca_h(th_) * gstomts + 8.d0 * gammastar        &
         &          * gstomts + jactts(:,ii) - 4.d0 * rlts_h(:) - SQRT((-4.d0    &
         &          * ca_h(th_) * gstomts + 8.d0 * gammastar * gstomts       &
         &          + jactts(:,ii) - 4.d0 * rlts_h(:)) ** 2.d0 + 16.d0          &
@@ -2279,7 +2276,7 @@
     do ii = 1,3 !loop for LAI values
       do jj = 1,3 !loop for CAI_g values    
         if(i_lai_function == 4) then    
-          assg__(jj,:,ii) =  frac_sung(ii) * ( (4.d0 * ca_h(th_) * gstomg(jj,:,ii) + 8.d0 * gammastar &
+          assg__(jj,:,ii) =   ( (4.d0 * ca_h(th_) * gstomg(jj,:,ii) + 8.d0 * gammastar &
           &         * gstomg(jj,:,ii) + jactg(:,ii) - 4.d0 * rlg_h(:)       &
           &         - SQRT((-4.d0 * ca_h(th_) * gstomg(jj,:,ii) + 8.d0       &
           &         * gammastar * gstomg(jj,:,ii) + jactg(:,ii) - 4.d0        &
@@ -2287,7 +2284,7 @@
           &         * gstomg(jj,:,ii) * (8.d0 * ca_h(th_) * gstomg(jj,:,ii)      &
           &         + jactg(:,ii) + 8.d0 * rlg_h(:)))) / 8.d0)  ! (3.22); (Out[319])
 
-          assgs__(jj,:,ii) =   frac_shadeg(ii) * ( (4.d0 * ca_h(th_) * gstomgs(jj,:,ii) + 8.d0 * gammastar &
+          assgs__(jj,:,ii) =    ( (4.d0 * ca_h(th_) * gstomgs(jj,:,ii) + 8.d0 * gammastar &
           &         * gstomgs(jj,:,ii) + jactgs(:,ii) - 4.d0 * rlgs_h(:)       &
           &         - SQRT((-4.d0 * ca_h(th_) * gstomgs(jj,:,ii) + 8.d0       &
           &         * gammastar * gstomgs(jj,:,ii) + jactgs(:,ii) - 4.d0        &

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1576,6 +1576,7 @@
       REAL*8 :: PARshade     
       REAL*8 :: par_shade_avg           
       REAL*8 :: par_sct                 
+      REAL*8 :: kappa_d                             
             
       
       select case(i_lai_function)
@@ -1612,6 +1613,8 @@
 
       
       case(3, 4) !dynamic LAI, with shaded/sunlit fractions
+      
+      kappa_d = 0.719d0
       
 !       * extinction coefficient (Xiao et al. (2015) eq.6, Campbell and Norman (1998) eq. 15.4)
         kappa_t = sqrt(i_chi_t**2+tan(phi_zenith(th_))**2)/(i_chi_t+1.774*(i_chi_t+1.182)**(-0.733) )        
@@ -1679,8 +1682,8 @@
                     !at the top of the canopy, shaded leaves receive PARdiff                   
                     !at the bottom of canopy, shaded leaves receive                     
                     !take the exponential weighted average of top and bottom (p260, Campbell&Norman):
-                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )   ) ) / &
-                                    ( sqrt(i_alpha_abs) * kappa_t * lai_lt(ii)    ) 
+                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lt(ii) )   ) ) / &
+                                    ( sqrt(i_alpha_abs) * kappa_d* lai_lt(ii)    ) 
               
                     !need to add the scattered direct PAR to the shaded PAR:
                     par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )  -  &
@@ -1707,8 +1710,8 @@
                     !at the top of the canopy, shaded leaves receive PARdiff                   
                     !at the bottom of canopy, shaded leaves receive                                        
                     !take the exponential weighted average of top and bottom (p260, Campbell&Norman):
-                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )   ) ) / &
-                                    ( sqrt(i_alpha_abs) * kappa_t * lai_lt(ii)    ) 
+                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lt(ii) )   ) ) / &
+                                    ( sqrt(i_alpha_abs) * kappa_d * lai_lt(ii)    ) 
               
                     !need to add the scattered direct PAR to the shaded PAR:
                     par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )  -  &
@@ -1755,8 +1758,8 @@
                     !at the top of the canopy, shaded leaves receive PARdiff                   
                     !at the bottom of canopy, shaded leaves receive                    
                     !take the exponential weighted average of top and bottom (p260, Campbell&Norman):
-                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_g * lai_lg(ii) )   ) ) / &
-                                    ( sqrt(i_alpha_abs) * kappa_g * lai_lg(ii)    ) 
+                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lg(ii) )   ) ) / &
+                                    ( sqrt(i_alpha_abs) * kappa_d * lai_lg(ii)    ) 
               
                     !need to add the scattered direct PAR to the shaded PAR:
                     par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_g * lai_lg(ii) )  -  &
@@ -1783,8 +1786,8 @@
                     !at the bottom of canopy, shaded leaves receive                    
                     !take the exponential weighted average of top and bottom (p260, Campbell&Norman):
                      
-                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_g * lai_lg(ii) )   ) ) / &
-                                    ( sqrt(i_alpha_abs) * kappa_g * lai_lg(ii)    ) 
+                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lg(ii) )   ) ) / &
+                                    ( sqrt(i_alpha_abs) * kappa_d * lai_lg(ii)    ) 
               
                     !need to add the scattered direct PAR to the shaded PAR:
                     par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_g * lai_lg(ii) )  -  &

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1694,7 +1694,7 @@
               
                     !----------------------------------------------------------
                     !sunlit leaves
-                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) ) + PARshade  
+                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade  )
               
                    jactt(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * PARsun ) &    
         &             / jmaxt_h(:))) * jmaxt_h(:) *  lat_sun(ii) ) +                                      &
@@ -1722,7 +1722,7 @@
               
                     !----------------------------------------------------------
                     !sunlit leaves
-                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) ) + PARshade                                     
+                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade )
                             
                 
                    jactt(:,ii)   = (1.d0 - p_E ** (-(i_alpha * PARsun ) &    

--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -1770,8 +1770,8 @@
               
                     !----------------------------------------------------------
                     !sunlit leaves
-                    PARsun = i_alpha_abs * (kappa_g * pardir_h(th_) ) + PARshade                
-              
+                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade )              
+                    
                     jactg(:,ii)   = ( (1.d0 - p_E ** (-(i_alpha * PARsun ) &    
                     &     / jmaxg_h(:))) * jmaxg_h(:)  *  lag_sun(ii)   ) +                                &
                     &     ( (1.d0 - p_E ** (-(i_alpha * PARshade )                                  &    
@@ -1800,8 +1800,7 @@
               
                     !----------------------------------------------------------
                     !sunlit leaves
-                    PARsun = i_alpha_abs * (kappa_g * pardir_h(th_) ) + PARshade                  
-           
+                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade )           
               
                     jactg(:,ii)   =  (1.d0 - p_E ** (-(i_alpha * PARsun ) &    
                     &     / jmaxg_h(:))) * jmaxg_h(:) *  lag_sun(ii)  

--- a/VOM_Fortran/VOM-docu/source/quickstart.rst
+++ b/VOM_Fortran/VOM-docu/source/quickstart.rst
@@ -63,6 +63,54 @@ This can be changed in vom_namelist, or on the command line:
 -n The VOM_namelist (filename can be different)
 
 
+To run successfully, these input-files are needed:
+
+**vom_namelist** 
+    Contains all settings to run the VOM.
+
+**pars.txt**
+    Contains the (optimized) vegetation parameters (only needed for single run).
+
+**dailyweather.prn**
+    Contains the meteorological forcing.
+
+By default, the executable looks for the vom_namelist in the current workdirectory. The default directory for the other files is /input, relative to the workdirectory. 
+This can be changed in vom_namelist, or on the command line:
+
+-i Inputpath to directory with dailyweather.prn, and optionally pars.txt. 
+
+-o Outputpath for all outputfiles.
+
+-n The VOM_namelist (filename can be different)
+
+
+
+Scripts for running the model
+-----------------------------
+In the folder VOM-scripts, two shell-scripts can be found for running the VOM:
+
+.. code-block:: bash
+
+    vom_parallel.job
+
+
+    run_vom.sh
+    
+
+The model is compiled and executed by the script run_vom.sh. It can be used in the following way:
+
+.. code-block:: bash
+
+    bash src_sh/run_vom.sh src/VOM/VOM_Fortran/ <inputdir> <dailyweather.prn> <soilprofile.par> <vom_namelist> <outputdir>
+
+
+vom_parallel.job is a job script for the LIST HPC using SLURM. Note that the script needs to be modified for own applications of the VOM on an HPC and serves here as an example. In this example, submitting a job with SLURM functions as follows:
+
+.. code-block:: bash
+
+    sbatch -o <output_logfile> -e <error_logfile> -n <number of cpu's> -J <jobname> vom_parallel.job <VOM-src> <input-directory> <dailyweather.prn> <soilprofile.par> <vom_namelist> <output-directory>
+
+
 
 Model modes
 -----------------

--- a/VOM_Fortran/VOM-scripts/run_vom.sh
+++ b/VOM_Fortran/VOM-scripts/run_vom.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# coding: utf-8
+#***********************************************************************
+#        run_vom.sh
+#        Compiles and runs the Vegetation Optimality Model (VOM).
+#
+#
+#-----------------------------------------------------------------------
+#        Authors: Remko Nijzink
+#        Now at: LIST (Luxembourg Institute of Science and Technology)
+#-----------------------------------------------------------------------
+#
+#  Copyright (C) 2022, Luxembourg Institute of Science and Technology, all rights reserved.
+#
+#    Code licensed under GPL version 2 or higher
+#    SPDX-License-Identifier: GPL-2.0-or-later
+#
+#***********************************************************************
+
+
+exe_dir=$1
+inputdir=$2
+input_weather=$3
+input_soil=$4
+nml_input=$5
+outputdir=$6
+restart_dir=$7
+
+
+date
+
+#compile code
+C_INCLUDE_PATH=$C_INCLUDE_PATH:/usr/include/
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/
+
+#check if paths are empty, use default otherwise
+if [ ! -d "$NC_INCLUDE" ]; then
+   NC_INCLUDE=/usr/include
+   echo $NC_INCLUDE
+fi
+
+if [ ! -d "$NC_LIB" ]; then
+   NC_LIB=/usr/lib
+   echo $NC_LIB
+fi
+
+
+
+make --directory $exe_dir FC=gfortran NC_INCLUDE=$NC_INCLUDE NC_LIB=$NC_LIB
+
+#check if the outputdir exists and else make one
+if [ ! -d "$outputdir" ]; then
+   mkdir $outputdir
+fi
+
+if [ -f "$restart_dir/sce_lastloop.txt" ]; then
+   cp $restart_dir/* $outputdir
+fi
+
+if [ ! -d "$inputdir" ]; then
+mkdir $inputdir
+cp $input_weather $inputdir
+cp $input_soil $inputdir
+
+fi
+
+#run the model 
+$exe_dir/model.x -i $inputdir -o $outputdir -n $nml_input
+
+#clean again
+make clean --directory $exe_dir
+
+date

--- a/VOM_Fortran/VOM-scripts/vom_parallel.job
+++ b/VOM_Fortran/VOM-scripts/vom_parallel.job
@@ -1,0 +1,69 @@
+#!/bin/sh
+# coding: utf-8
+#***********************************************************************
+#        vom_parallel.sh
+#        Jobscript for the LIST HPC, to run run_vom.sh.
+#
+#
+#-----------------------------------------------------------------------
+#        Authors: Remko Nijzink
+#        Now at: LIST (Luxembourg Institute of Science and Technology)
+#-----------------------------------------------------------------------
+#
+#  Copyright (C) 2022, Luxembourg Institute of Science and Technology, all rights reserved.
+#
+#    Code licensed under GPL version 2 or higher
+#    SPDX-License-Identifier: GPL-2.0-or-later
+#
+#***********************************************************************
+#
+# Your job name
+#SBATCH --job-name=VOMexp
+#
+# Use current working directory
+#
+#
+#SBATCH -e /home/int/eva/nijzink/logfiles/err
+#SBATCH -o /home/int/eva/nijzink/logfiles/out
+#SBATCH --account=wave
+# pe (Parallel environment) request. Set your number of processors here.
+#SBATCH -n 4
+#SBATCH --time=47:00:00
+#
+# The following output will show in the output file. Used for debugging.
+echo "Got $SLURM_NNODES processors."
+#
+# load modules
+module load userspace/tr17.10
+module load userspace/spack
+module load gcc-8.2.0-gcc-7.2.0-la27vub
+module load netcdf-fortran-4.5.2-gcc-8.2.0-y4qfiu6
+#
+# to avoid an error message in renku
+#export LC_ALL='en_US.UTF-8'
+#export LANG='en_US.UTF-8'
+#module load null shared use.own conda
+#
+#files to be tracked with renku
+exe_src=$2
+dailyweather_input=$1
+
+NC_INCLUDE=/trinity/shared/apps/spack/opt/spack/linux-centos7-x86_64/gcc-8.2.0/netcdf-fortran-4.5.2-y4qfiu6nzx3voevihng2ihu4eunwfc3x/include
+NC_LIB=/trinity/shared/apps/spack/opt/spack/linux-centos7-x86_64/gcc-8.2.0/netcdf-fortran-4.5.2-y4qfiu6nzx3voevihng2ihu4eunwfc3x/lib/
+
+export NC_INCLUDE
+export NC_LIB
+
+date
+source /home/int/eva/nijzink/miniconda3/etc/profile.d/conda.sh
+conda activate renku
+
+#inputs:
+#workdir
+#dailyweather.prn
+#vom_namelist
+#VOM-code
+
+renku run bash src_sh/run_vom.sh $@
+
+date


### PR DESCRIPTION
This is a PR in progress to incorporate the feature of enabling dynamic leaf area index for trees and grasses, prepared by @rcnijzink. Initially, it is a copy of #67, but still needs to be tested and documented before merging.

Here is what @rcnijzink wrote in #67:

This branch had my latest edits for the LAI in the VOM (just before EGU 2022). I think it would be best to merge this into a branch on git@github.com:schymans/VOM.git, then you could start from there. I tried below to give an overview on what I did.

This branch includes a first attempt to separate PAR into PAR shade and PAR sunlit, based on the approach in Campbell & Norman.  I followed the example on p260 (example 15.2). Specifically:

- estimate average PAR on shaded leaves (transpmode.f90, lines 1685 and 1713, first equation p261 Campbell & Norman):

```
                    par_shade_avg = (pardiff_h(th_) * ( 1.d0 - p_E ** ( -sqrt(i_alpha_abs) * kappa_d * lai_lt(ii) )   ) ) / &
                                    ( sqrt(i_alpha_abs) * kappa_d* lai_lt(ii)    ) 
```

- determine scattered PAR (transpmode.f90, lines 1689 and 1717)::

```
                    par_sct = 0.5* ( pardir_h(th_) * p_E ** (-sqrt(i_alpha_abs) * kappa_t * lai_lt(ii) )  -  &
                                    pardir_h(th_) * p_E ** (-kappa_t * lai_lt(ii) ) )
```

the above is the same as  the calculation on p261 of Campbell & Norman, with scattered PAR as Qsc = 0.5 (Qbt - Qb), with Qbt the top beam radiation and Qb bottom beam radiation. 

- Eventually, PARshade and PARsun are determined like this:

`                    PARshade = (par_sct + par_shade_avg) * i_alpha_abs`

`                    PARsun = i_alpha_abs * (kappa_t * pardir_h(th_) + PARshade )`


 On p261 of Campbell & Norman, these are the equations for Qsh and Qsl.
