### PR TITLE
hourlyweather input correction in transpmodel

### DIFF
--- a/VOM_Fortran/VOM-code/transpmodel.f90
+++ b/VOM_Fortran/VOM-code/transpmodel.f90
@@ -890,7 +890,7 @@
         do i = 1, c_maxhour
         
           !read hourly inputs
-          read(kfile_hourlyweather, '(5i8,6e11.4)') h, dummyint1,       &
+          read(kfile_hourlyweather, '(5i8,8e11.4)') h, dummyint1,       &
      &      dummyint2, dummyint3, dummyint4, tair_h(i), vp_h(i),       &
      &      par_h(i),pardiff_h(i),pardir_h(i), rain_h(i), press_h(i), ca_h(i)   
           if (par_h(i) .lt. 0.d0) par_h(i) = 0.d0


### PR DESCRIPTION
When the model is run with hourly weather (changing i_write_h=0 to =1, in vom_namelist) the model does not run as the vom_get_hourly_clim () subroutine in transpmodel.f90 on line 893 was trying to load in 11 instead of 13 inputs the the hourly weather uses. This has been updated to input 13. #77 